### PR TITLE
chore(ci): rename trivy check to grype after scanner migration

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
     uses: mac-lucky/actions-shared-workflows/.github/workflows/dependabot-auto-merge-reusable.yml@master
     with:
       # Match the job names from the CI/CD pipeline (nested in reusable workflow)
-      code_analysis_check_name: "Code Analysis (trivy)"
+      code_analysis_check_name: "Code Analysis (grype)"
       container_test_check_name: ""
       kubernetes_test_check_name: "Kubernetes Integration Test"
       


### PR DESCRIPTION
## Summary
- Updated `code_analysis_check_name` from `"Code Analysis (trivy)"` to `"Code Analysis (grype)"` in the dependabot auto-merge workflow to reflect the scanner migration from Trivy to Grype in the shared workflows.